### PR TITLE
Fix the bug of undefined variable

### DIFF
--- a/imaginator/test/inference_single_image_IP2P.py
+++ b/imaginator/test/inference_single_image_IP2P.py
@@ -66,6 +66,7 @@ def main():
 
     # 3. Edited Prompt input_ids
     text_prompt = args.text_prompt
+    save_dir = args.save_dir
 
     input_image.save(os.path.join(save_dir, f'{(pair_id + 1):04d}_input.png'))
 


### PR DESCRIPTION
File `imaginator\test\inference_single_image_IP2P.py`, line 69
```python
text_prompt = args.text_prompt
save_dir = args.save_dir # save_dir is not defined

input_image.save(os.path.join(save_dir, f'{(pair_id + 1):04d}_input.png'))
```